### PR TITLE
Set environment variables before running build script.

### DIFF
--- a/target-machine/home/deploy/bin/build-app
+++ b/target-machine/home/deploy/bin/build-app
@@ -2,5 +2,7 @@
 
 export APP_DIR=$1
 build=$(cat "$APP_DIR/Procfile" | grep build | sed 's|build:||')
-cd "$APP_DIR" && sh -c "$build"
+cd "$APP_DIR"
+. .env
+sh -c "$build"
 cd -


### PR DESCRIPTION
There is a current bug in which the build command does not have access to environment variables. This patch makes the environment variables accessible to the build program which is defined in the Procfile.
