### PR TITLE
Turn off `set -x` by default

### DIFF
--- a/build-ami
+++ b/build-ami
@@ -1,4 +1,6 @@
-#!/bin/bash -ex
+#!/bin/bash -e
+
+[ -n "$AMZN_DEBUG" ] && set -x
 
 FRAMEPATH=$1
 NAME=${FRAMEPATH##*/} # remove everything before and including last slash

--- a/setup-base
+++ b/setup-base
@@ -1,4 +1,6 @@
-#!/bin/bash -ex
+#!/bin/bash -e
+
+[ -n "$AMZN_DEBUG" ] && set -x
 
 # Create a deploy user without a password and with a home directory.
 sudo useradd -m deploy -s /bin/bash

--- a/target-machine/home/deploy/bin/build-app
+++ b/target-machine/home/deploy/bin/build-app
@@ -1,4 +1,6 @@
-#!/bin/bash -ex
+#!/bin/bash -e
+
+[ -n "$AMZN_DEBUG" ] && set -x
 
 export APP_DIR=$1
 cd "$APP_DIR"

--- a/target-machine/home/deploy/bin/configure-logging
+++ b/target-machine/home/deploy/bin/configure-logging
@@ -1,4 +1,6 @@
-#!/bin/bash -ex
+#!/bin/bash -e
+
+[ -n "$AMZN_DEBUG" ] && set -x
 
 export LOGGING_CONFIG=$1
 if [ "$LOGGING_CONFIG" != "" ]; then

--- a/target-machine/home/deploy/bin/configure-upstart
+++ b/target-machine/home/deploy/bin/configure-upstart
@@ -1,4 +1,6 @@
-#!/bin/bash -ex
+#!/bin/bash -e
+
+[ -n "$AMZN_DEBUG" ] && set -x
 
 export APP_DIR=$1
 

--- a/target-machine/home/deploy/bin/deploy
+++ b/target-machine/home/deploy/bin/deploy
@@ -1,4 +1,6 @@
-#!/bin/bash -ex
+#!/bin/bash -e
+
+[ -n "$AMZN_DEBUG" ] && set -x
 
 export RELEASE_URL=$1
 export APP_DIR=/home/deploy/app


### PR DESCRIPTION
If `AMZN_DEBUG` is set in the environment it will be set.

Fixes ryandotsmith/amzn-ship#10 for amzn-base components on the target machine.